### PR TITLE
Add Google Autocomplete 

### DIFF
--- a/lib/Google/google_autocomplete.js
+++ b/lib/Google/google_autocomplete.js
@@ -1,0 +1,34 @@
+const { XMLHttpRequest } = require('xmlhttprequest')
+const { GOOGLE_URLS: { GOOGLE_AUTOCOMPLETE } } = require('./settings')
+
+String.prototype.format = function() {
+	var args = arguments
+	return this.replace(/\{(\d+)\}/g, function (m, i) {
+		return args[i]
+	})
+}
+
+class GAutoComplete {
+	constructor(search_word){
+		this.search_word = search_word
+		this.result = []
+		this.URL = GAutoComplete.URL
+	}
+
+	get_all(){
+		let search_url = this.URL.format(this.search_word)
+		const page = new XMLHttpRequest()
+			  page.open( "GET", search_url, false)
+			  page.send()
+		let rawresult = JSON.parse(page.responseText)
+		let result = rawresult[0].map(arr => arr[0].replace(new RegExp('<[^>]*>', 'g'), ''))
+
+		return {
+			search_word : this.search_word,
+			result,
+		}
+	}
+}
+
+GAutoComplete.URL = GOOGLE_AUTOCOMPLETE
+module.exports = GAutoComplete

--- a/lib/Google/settings.js
+++ b/lib/Google/settings.js
@@ -4,7 +4,8 @@ GOOGLE_URLS = {
 	'GOOGLE_VIDEO': 'https://www.google.com/search?q={0}&tbm=vid&start={1}', 
 	'GOOGLE_BOOKS': 'https://www.google.com/search?q={0}&tbm=bks&start={1}',
 	'GOOGLE_NEWS': 'https://www.google.com/search?q={0}&tbm=nws&start={1}', 
-	'GOOGLE_SHOP': 'https://www.google.com/search?q={0}&tbm=shop&start={1}'
+	'GOOGLE_SHOP': 'https://www.google.com/search?q={0}&tbm=shop&start={1}',
+	'GOOGLE_AUTOCOMPLETE': 'https://www.google.com/complete/search?q=${0}&hl=id&ds=i&client=gws-wiz&xhr=t'
 }
 
 module.exports = { GOOGLE_URLS }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,5 +5,6 @@ module.exports = {
 	GShop: require('./Google/google_shop'), 
 	GScholar: require('./Google/google_scholar'), 
 	GBooks: require('./Google/google_books'), 
+        GAutoComplete : require("./Google/google_autocomplete"),
 	BASearch: require('./Baidu/baidu_search')
 }


### PR DESCRIPTION
Hi @michael-act 👋

## Enhancement
I added a new feature, **google search autocomplete**, to give search suggestions based on keyword

example
```js
let GAuto  = new GAutoComplete("example of")
GAuto.get_all()
```

result
```js
{
  search_word: 'example of',
  result: [
    'example of resume',
    'example of cv',
    'example of cover letter',
    'example of formal letter',
    'example of essay',
    'example of abstract',
    'example of literature review',
    'example of thesis statement',
    'example of executive summary',
    'example of lesson plan'
  ]
}
```

> I hope it can be useful